### PR TITLE
[Hotfix/#49] TestFlight 1.9(2) 버그 수정

### DIFF
--- a/Cherish-iOS/Cherish-iOS/Global/Base/BaseController.swift
+++ b/Cherish-iOS/Cherish-iOS/Global/Base/BaseController.swift
@@ -13,6 +13,7 @@ class BaseController: UIViewController {
     override func viewDidLoad() {
         self.view.backgroundColor = .systemBackground
         self.navigationController?.isNavigationBarHidden = true
+        self.hidesBottomBarWhenPushed = true
         self.setFeebBackGenerator()
     }
     

--- a/Cherish-iOS/Cherish-iOS/Global/Extension/UIView+Extension.swift
+++ b/Cherish-iOS/Cherish-iOS/Global/Extension/UIView+Extension.swift
@@ -46,6 +46,12 @@ extension UIView {
         self.layer.masksToBounds = true
     }
     
+    func makePartialRounded(cornerRadius: CGFloat, maskedCorners: CACornerMask) {
+            clipsToBounds = true
+            self.layer.cornerRadius = cornerRadius
+            self.layer.maskedCorners = CACornerMask(arrayLiteral: maskedCorners)
+        }
+    
     // Set UIView's Shadow
     func dropShadow(color: UIColor, offSet: CGSize, opacity: Float, radius: CGFloat) {
         

--- a/Cherish-iOS/Cherish-iOS/Screens/AddUser/Controllers/AddUserVC.swift
+++ b/Cherish-iOS/Cherish-iOS/Screens/AddUser/Controllers/AddUserVC.swift
@@ -18,20 +18,13 @@ class AddUserVC: BaseController {
     }
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.navigationController?.navigationBar.isHidden = true
-        self.tabBarController?.tabBar.isHidden = true
         UserDefaults.standard.set(false, forKey: "isPlantExist")
-    }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        self.navigationController?.navigationBar.isHidden = true
-        self.tabBarController?.tabBar.isHidden = true
-    }
-    
+    }    
     
     @IBAction func touchUpToAddNC(_ sender: UIButton) {
         print("hello")
         if let vc = self.storyboard?.instantiateViewController(identifier: "SelectFriendSearchBar") as? SelectFriendSearchBar {
+//            vc.hidesBottomBarWhenPushed = true
             self.navigationController?.pushViewController(vc, animated: true)
         }
     }

--- a/Cherish-iOS/Cherish-iOS/Screens/AddUser/Controllers/PlantResultVC.swift
+++ b/Cherish-iOS/Cherish-iOS/Screens/AddUser/Controllers/PlantResultVC.swift
@@ -78,8 +78,8 @@ class PlantResultVC: BaseController {
     
     @IBAction func startToMain(_ sender: UIButton) {
         NotificationCenter.default.post(name: .addUser, object: nil)
-        let storyBoard: UIStoryboard = UIStoryboard(name: "CherishMain", bundle: nil)
-        if let vc = storyBoard.instantiateViewController(identifier: "CherishMainVC") as? CherishMainVC {
+        let storyboard = UIStoryboard(name: "TabBar", bundle: nil)
+        if let vc = storyboard.instantiateViewController(withIdentifier: "CherishTabBarController") as? CherishTabBarController {
             isCherishDataChanged.shared.status = true
             UserDefaults.standard.set(true, forKey: "isPlantExist")
             UserDefaults.standard.set("", forKey: "selectedNickNameData")

--- a/Cherish-iOS/Cherish-iOS/Screens/AddUser/Controllers/SelectFriendSearchBar.swift
+++ b/Cherish-iOS/Cherish-iOS/Screens/AddUser/Controllers/SelectFriendSearchBar.swift
@@ -59,14 +59,12 @@ class SelectFriendSearchBar: BaseController, UITableViewDataSource, UITableViewD
         super.viewDidLoad()
         /// 이렇게 하면 버튼 타이틀이 가운데로 안온다
 //        nextBtn.isEnabled = false
-        let cell = tableView.dequeueReusableCell(withIdentifier: "SelectFriendCell")
         tableView.separatorStyle = .none
         tableView.dataSource = self
         tableView.delegate = self
         searchBar.delegate = self
         tableView.tableFooterView = UIView()
         tableView.register(UINib(nibName: radioButton, bundle: nil), forCellReuseIdentifier: radioButton)
-        resetSelectFriendVC()
         setSearchBar()
         noContactsView.isHidden = true
         checkContactArray()
@@ -286,11 +284,6 @@ class SelectFriendSearchBar: BaseController, UITableViewDataSource, UITableViewD
         searchBar.setPositionAdjustment(UIOffset(horizontal: 10.0, vertical: 0.0), for: .search)
         searchBar.searchTextField.textColor = UIColor.cherishBlack
         searchBar.searchTextField.font = UIFont.init(name: "NotoSansCJKKR-Regular", size: 14)
-    }
-    
-    func resetSelectFriendVC() {
-        self.navigationController?.navigationBar.isHidden = true
-        self.tabBarController?.tabBar.isHidden = true
     }
     
     private func updateSelectedIndex(_ index: Int) {

--- a/Cherish-iOS/Cherish-iOS/Screens/CherishMain/Controllers/CherishMainVC.swift
+++ b/Cherish-iOS/Cherish-iOS/Screens/CherishMain/Controllers/CherishMainVC.swift
@@ -24,10 +24,13 @@ class CherishMainVC: OverlayContainerViewController {
         super.viewDidLoad()
         //cherishPeople cell 클릭되었을 때 노티를 보낸걸 감지
         NotificationCenter.default.addObserver(self, selector: #selector(scrollNotchDownAction), name: .cherishPeopleCellClicked, object: nil)
-        
         navigationBarHidden()
         makeOverlayContainerContents()
-        
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        self.hidesBottomBarWhenPushed = false
     }
     
     func navigationBarHidden() {

--- a/Cherish-iOS/Cherish-iOS/Screens/CherishMain/Controllers/DetailContentVC.swift
+++ b/Cherish-iOS/Cherish-iOS/Screens/CherishMain/Controllers/DetailContentVC.swift
@@ -65,10 +65,8 @@ class DetailContentVC: BaseController {
     
     //MARK: - 헤더 뷰 라운드로 만드는 함수
     func makeHeaderViewCornerRadius() {
-        self.view.layer.cornerRadius = 30
-        headerView.clipsToBounds = true
-        headerView.layer.cornerRadius = 30
-        headerView.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+        self.view.makePartialRounded(cornerRadius: 30, maskedCorners: [.layerMinXMinYCorner, .layerMaxXMinYCorner])
+        self.view.clipsToBounds = true
     }
     
     //MARK: - 메인뷰 데이터 받아오는 함수

--- a/Cherish-iOS/Cherish-iOS/Screens/CherishMain/Controllers/DetailContentVC.swift
+++ b/Cherish-iOS/Cherish-iOS/Screens/CherishMain/Controllers/DetailContentVC.swift
@@ -82,7 +82,7 @@ class DetailContentVC: BaseController {
                         UserDefaults.standard.set(false, forKey: "isPlantExist")
                         let storyBoard: UIStoryboard = UIStoryboard(name: "AddUser", bundle: nil)
                         if let vc = storyBoard.instantiateViewController(identifier: "AddUserVC") as? AddUserVC {
-                            vc.hidesBottomBarWhenPushed = true
+//                            vc.hidesBottomBarWhenPushed = true
                             self?.navigationController?.setViewControllers([vc], animated: true)
                         }
                     } else {
@@ -267,6 +267,7 @@ class DetailContentVC: BaseController {
     @IBAction func moveToSelectFriend(_ sender: Any) {
         let storyBoard: UIStoryboard = UIStoryboard(name: "AddUser", bundle: nil)
         if let vc = storyBoard.instantiateViewController(identifier: "SelectFriendSearchBar") as? SelectFriendSearchBar {
+//            vc.hidesBottomBarWhenPushed = true
             self.navigationController?.pushViewController(vc, animated: true)
         }
     }

--- a/Cherish-iOS/Cherish-iOS/Screens/CherishMain/Controllers/MainContentVC.swift
+++ b/Cherish-iOS/Cherish-iOS/Screens/CherishMain/Controllers/MainContentVC.swift
@@ -57,12 +57,12 @@ class MainContentVC: BaseController {
         setDataWithSelectedData()
         setAutolayout()
         setSnowingAnimation()
-        self.tabBarController?.tabBar.isHidden = false
     }
     
     
     //MARK: - viewWillAppear
     override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         LoadingHUD.show()
         setAutolayout()
         // 식물카드로 넘어갈 때 경우의 수 나누기 위해 false로 바꾼다.
@@ -85,9 +85,6 @@ class MainContentVC: BaseController {
                 view.backgroundColor = .white
             }
         }
-        // 식물상세페이지로 네비게이션 연결 후 탭바가 사라지기 때문에
-        // popViewController 액션으로 다시 메인뷰로 돌아왔을 때 탭바가 나타나야 한다.
-        self.tabBarController?.tabBar.isHidden = false
         LoadingHUD.hide()
     }
     
@@ -1055,7 +1052,7 @@ class MainContentVC: BaseController {
         
         let storyBoard: UIStoryboard = UIStoryboard(name: "PlantDetail", bundle: nil)
         if let vc = storyBoard.instantiateViewController(identifier: "PlantDetailVC") as? PlantDetailVC {
-            
+//            vc.hidesBottomBarWhenPushed = true
             self.navigationController?.pushViewController(vc, animated: true)
         }
     }

--- a/Cherish-iOS/Cherish-iOS/Screens/Login/Controllers/LoginVC.swift
+++ b/Cherish-iOS/Cherish-iOS/Screens/Login/Controllers/LoginVC.swift
@@ -237,8 +237,7 @@ class LoginVC: BaseController {
     func goToCherishMainView(){
         let tabBarStoyboard: UIStoryboard = UIStoryboard(name: "TabBar", bundle: nil)
         if let tabBarVC = tabBarStoyboard.instantiateViewController(identifier: "CherishTabBarController") as? CherishTabBarController {
-            tabBarVC.modalPresentationStyle = .fullScreen
-            self.present(tabBarVC, animated: true, completion: nil)
+            self.navigationController?.setViewControllers([tabBarVC], animated: true)
         }
     }
     

--- a/Cherish-iOS/Cherish-iOS/Screens/MyPage/Controllers/MyPageSearchContactVC.swift
+++ b/Cherish-iOS/Cherish-iOS/Screens/MyPage/Controllers/MyPageSearchContactVC.swift
@@ -50,7 +50,6 @@ class MyPageSearchContactVC: BaseController, UITableViewDelegate, UITableViewDat
         contactTV.reloadData()
         contactTV.tableFooterView = UIView()
         contactTV.register(UINib(nibName: radioButton, bundle: nil), forCellReuseIdentifier: radioButton)
-        resetSelectFriendVC()
         filteredData = friendList
         self.moveToAddBtn.setBackgroundImage(UIImage(named: "btnNextUnselected"), for: .normal)
         moveToAddBtn.layer.zPosition = 1
@@ -86,11 +85,6 @@ class MyPageSearchContactVC: BaseController, UITableViewDelegate, UITableViewDat
             // 문자로 시작하는 문자열 뒤에 숫자로 시작하는 문자열 병합
             friendList.append(contentsOf: startNumberArray)
         }
-    }
-    
-    func resetSelectFriendVC() {
-        self.navigationController?.navigationBar.isHidden = true
-        self.tabBarController?.tabBar.isHidden = true
     }
     
     private func updateSelectedIndex(_ index: Int) {

--- a/Cherish-iOS/Cherish-iOS/Screens/MyPage/Controllers/MyPageSearchPlantVC.swift
+++ b/Cherish-iOS/Cherish-iOS/Screens/MyPage/Controllers/MyPageSearchPlantVC.swift
@@ -43,7 +43,6 @@ class MyPageSearchPlantVC: BaseController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.tabBarController?.tabBar.isHidden = true
         setSearchBar()
         plantTV.separatorStyle = .none
         plantTV.delegate = self
@@ -54,9 +53,7 @@ class MyPageSearchPlantVC: BaseController {
     
     override func viewWillAppear(_ animated: Bool) {
         // 식물 수정한 결과 가져오기 위함!
-        // plantTV.reloadData()
         setPlantData()
-        self.tabBarController?.tabBar.isHidden = true
     }
     
     func setSearchBar() {
@@ -121,6 +118,7 @@ class MyPageSearchPlantVC: BaseController {
         let storyBoard: UIStoryboard = UIStoryboard(name: "AddUser", bundle: nil)
         
         guard let dvc = storyBoard.instantiateViewController(identifier: "SelectFriendSearchBar") as? SelectFriendSearchBar else {return}
+//        dvc.hidesBottomBarWhenPushed = true
         self.navigationController?.pushViewController(dvc, animated: true)
     }
     }
@@ -179,7 +177,7 @@ extension MyPageSearchPlantVC: UITableViewDelegate, UITableViewDataSource {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let storyBoard: UIStoryboard = UIStoryboard(name: "PlantDetail", bundle: nil)
         guard let dvc = storyBoard.instantiateViewController(identifier: "PlantDetailVC") as? PlantDetailVC else { return }
-
+        
         // 분기 처리
         // searchBar 썼으면 myCherish 배열 다시 만들어서 사용해야할듯 -> filtered에 append할 때 같이 넣어주기
         
@@ -201,7 +199,7 @@ extension MyPageSearchPlantVC: UITableViewDelegate, UITableViewDataSource {
         UserDefaults.standard.set(plantIsSelected, forKey: "calendarPlantIsSelected")
         print(UserDefaults.standard.bool(forKey: "plantIsSelected"))
 //        print(UserDefaults.standard.integer(forKey: "selectedCherish"))
-        
+//        dvc.hidesBottomBarWhenPushed = true
         self.navigationController?.pushViewController(dvc, animated: true)
     }
 }

--- a/Cherish-iOS/Cherish-iOS/Screens/MyPage/Controllers/MyPageVC.swift
+++ b/Cherish-iOS/Cherish-iOS/Screens/MyPage/Controllers/MyPageVC.swift
@@ -69,6 +69,8 @@ class MyPageVC: BaseController {
     }
     
     override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        self.hidesBottomBarWhenPushed = false
         segmentView.buttonAction(sender: UIButton(type: UIButton.ButtonType(rawValue: 0x7fa0b649fc30)!))
         LoadingHUD.show()
         getMypageData()
@@ -243,6 +245,7 @@ class MyPageVC: BaseController {
         let storyBoard: UIStoryboard = UIStoryboard(name: "AddUser", bundle: nil)
         
         guard let dvc = storyBoard.instantiateViewController(identifier: "SelectFriendSearchBar") as? SelectFriendSearchBar else {return}
+//        dvc.hidesBottomBarWhenPushed = true
         self.navigationController?.pushViewController(dvc, animated: true)
     }
 }

--- a/Cherish-iOS/Cherish-iOS/Screens/MyPage/Controllers/MypagePlantVC.swift
+++ b/Cherish-iOS/Cherish-iOS/Screens/MyPage/Controllers/MypagePlantVC.swift
@@ -28,7 +28,6 @@ class MypagePlantVC: BaseController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        self.tabBarController?.tabBar.isHidden = false
         setPlantData()
     }
     
@@ -109,6 +108,7 @@ extension MypagePlantVC: UITableViewDelegate, UITableViewDataSource {
         
         let storyBoard: UIStoryboard = UIStoryboard(name: "PlantDetail", bundle: nil)
         guard let dvc = storyBoard.instantiateViewController(identifier: "PlantDetailVC") as? PlantDetailVC else { return }
+//        dvc.hidesBottomBarWhenPushed = true
         self.navigationController?.pushViewController(dvc, animated: true)
     }
 }

--- a/Cherish-iOS/Cherish-iOS/Screens/Onboarding/Controllers/OnboardingVC.swift
+++ b/Cherish-iOS/Cherish-iOS/Screens/Onboarding/Controllers/OnboardingVC.swift
@@ -40,7 +40,6 @@ class OnboardingVC: BaseController {
         let storyBoard: UIStoryboard = UIStoryboard(name: "Login", bundle: nil)
         if let vc = storyBoard.instantiateViewController(identifier: "LoginVC") as? LoginVC {
             UserDefaults.standard.set(true, forKey: "OnboardingHaveSeen")
-            self.navigationController?.pushViewController(vc, animated: true)
             self.navigationController?.setViewControllers([vc], animated: true)
         }
     }
@@ -49,7 +48,6 @@ class OnboardingVC: BaseController {
         let storyBoard: UIStoryboard = UIStoryboard(name: "Login", bundle: nil)
         if let vc = storyBoard.instantiateViewController(identifier: "LoginVC") as? LoginVC {
             UserDefaults.standard.set(true, forKey: "OnboardingHaveSeen")
-            self.navigationController?.pushViewController(vc, animated: true)
             self.navigationController?.setViewControllers([vc], animated: true)
         }
     }

--- a/Cherish-iOS/Cherish-iOS/Screens/PlantDetail/Controllers/PlantDetailVC.swift
+++ b/Cherish-iOS/Cherish-iOS/Screens/PlantDetail/Controllers/PlantDetailVC.swift
@@ -121,8 +121,6 @@ class PlantDetailVC: BaseController {
     
     //MARK: - NC,TC 속성 정의함수
     func setControllers() {
-        self.navigationController?.navigationBar.isHidden = true
-        self.tabBarController?.tabBar.isHidden = true
         self.edgesForExtendedLayout = UIRectEdge.bottom
     }
     

--- a/Cherish-iOS/Cherish-iOS/Screens/ShowMore/Controllers/ShowMoreVC.swift
+++ b/Cherish-iOS/Cherish-iOS/Screens/ShowMore/Controllers/ShowMoreVC.swift
@@ -32,6 +32,7 @@ final class ShowMoreVC: BaseController {
         $0.press {
             let storyboard = UIStoryboard(name: "ShowMore", bundle: nil)
             let NicknameChangeVC = storyboard.instantiateViewController(identifier: "NicknameChangeVC") as! NicknameChangeVC
+            NicknameChangeVC.hidesBottomBarWhenPushed = true
             self.navigationController?.pushViewController(NicknameChangeVC, animated: true)
         }
     }
@@ -65,7 +66,8 @@ final class ShowMoreVC: BaseController {
     }
     
     override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(true)
+        super.viewWillAppear(animated)
+        self.hidesBottomBarWhenPushed = false
         self.setUserInfo()
         self.setUserImage()
         self.showmoreTableView.reloadSections(IndexSet(integer: 1), with: .automatic)
@@ -168,7 +170,7 @@ extension ShowMoreVC {
     }
     
     private func logoutAlert() {
-        self.makeAlertWithCancel(title: "로그아웃", message: "정말로 로그아웃 하시겠습니가?") { [weak self] _ in
+        self.makeAlertWithCancel(title: "로그아웃", message: "로그아웃 하시겠습니까?") { [weak self] _ in
             //로그아웃하기 위해 자동로그인을 위해 사용되었던
             //UserDefualts에 저장된 값들을 삭제해준다
             UserDefaults.standard.removeObject(forKey: "loginEmail")
@@ -427,7 +429,7 @@ extension ShowMoreVC: ShowMoreSwitchDelegate {
             // OFF -> ON
             if sender.isOn {
                 let lock = SetLockVC()
-                lock.hidesBottomBarWhenPushed = true
+//                    $0.hidesBottomBarWhenPushed = true
                 self.navigationController?.pushViewController(lock, animated: true)
             // ON -> OFF
             } else {

--- a/Cherish-iOS/Cherish-iOS/Screens/ShowMore/Controllers/ShowMoreVC.swift
+++ b/Cherish-iOS/Cherish-iOS/Screens/ShowMore/Controllers/ShowMoreVC.swift
@@ -179,7 +179,7 @@ extension ShowMoreVC {
             let storyboard = UIStoryboard(name: "Login", bundle: nil)
             guard let loginView = storyboard.instantiateViewController(withIdentifier: "LoginVC") as? LoginVC else { return }
             guard let window = UIApplication.shared.windows.first(where: \.isKeyWindow) else { return }
-            let rootView = UINavigationController(rootViewController: loginView)
+            let rootView = NavigationController(rootViewController: loginView)
             window.rootViewController = rootView
             let options: UIView.AnimationOptions = .transitionCrossDissolve
             let duration: TimeInterval = 0.3

--- a/Cherish-iOS/Cherish-iOS/Screens/TabBar/Controllers/CherishTabBarController.swift
+++ b/Cherish-iOS/Cherish-iOS/Screens/TabBar/Controllers/CherishTabBarController.swift
@@ -47,8 +47,6 @@ class CherishTabBarController: UITabBarController {
     }
     
     func setTabBar() {
-        self.tabBar.tintColor = UIColor.cherishBlack
-    
         let CherishMain = UIStoryboard.init(name: "CherishMain", bundle: nil)
         guard let main = CherishMain.instantiateViewController(identifier: "CherishMainVC") as? CherishMainVC else { return }
         let mainTab = NavigationController(rootViewController: main).then {
@@ -73,6 +71,7 @@ class CherishTabBarController: UITabBarController {
         let tabs =  [mainTab, pageTab, showMoreTab]
         tabBar.layer.shadowOpacity = 0
         tabBar.layer.shadowOffset = CGSize(width: 0, height: 0)
+        tabBar.tintColor = UIColor.cherishBlack
         tabBar.barTintColor = .white
         self.setViewControllers(tabs, animated: false)
     }

--- a/Cherish-iOS/Cherish-iOS/Screens/TabBar/Controllers/CherishTabBarController.swift
+++ b/Cherish-iOS/Cherish-iOS/Screens/TabBar/Controllers/CherishTabBarController.swift
@@ -22,8 +22,8 @@ class CherishTabBarController: UITabBarController {
     }
     
     override func viewDidLayoutSubviews() {
+        super.viewWillLayoutSubviews()
         if screenWidth >= 414 && screenHeight >= 896 {
-            super.viewWillLayoutSubviews()
             var tabFrame: CGRect = self.tabBar.frame
             self.tabBar.frame.size.height = 55
             tabFrame.size.height = 96.6

--- a/Cherish-iOS/Cherish-iOS/Screens/TabBar/Controllers/CherishTabBarController.swift
+++ b/Cherish-iOS/Cherish-iOS/Screens/TabBar/Controllers/CherishTabBarController.swift
@@ -9,7 +9,7 @@ import UIKit
 import Then
 
 class CherishTabBarController: UITabBarController {
-
+    
     // 뷰 전체 폭 길이
     private let screenWidth = UIScreen.main.bounds.size.width
     
@@ -61,18 +61,24 @@ class CherishTabBarController: UITabBarController {
             $0.tabBarItem.selectedImage = UIImage(named: "icnMypageSelected")?.withAlignmentRectInsets(UIEdgeInsets(top: 9, left: 0, bottom: -8.5, right: 0))
         }
         
-        // 더보기탭
         let showMoreTab = NavigationController(rootViewController: ShowMoreVC()).then {
             $0.tabBarItem.image = UIImage(named: "icnMoreUnselected")?.withAlignmentRectInsets(UIEdgeInsets(top: 9, left: 0, bottom: -8.5, right: 0))
             $0.tabBarItem.selectedImage = UIImage(named: "icnMoreSelected")?.withAlignmentRectInsets(UIEdgeInsets(top: 9, left: 0, bottom: -8.5, right: 0))
-            
         }
         
         let tabs =  [mainTab, pageTab, showMoreTab]
-        tabBar.layer.shadowOpacity = 0
-        tabBar.layer.shadowOffset = CGSize(width: 0, height: 0)
+        let appearance = UITabBarAppearance().then {
+            $0.configureWithOpaqueBackground()
+            $0.shadowColor = .clear
+            $0.backgroundColor = .white
+        }
+        tabBar.standardAppearance = appearance
+        if #available(iOS 15.0, *) {
+            tabBar.scrollEdgeAppearance = tabBar.standardAppearance
+        }
         tabBar.tintColor = UIColor.cherishBlack
-        tabBar.barTintColor = .white
+        tabBar.isTranslucent = false
+        tabBar.layer.masksToBounds = false
         self.setViewControllers(tabs, animated: false)
     }
 }

--- a/Cherish-iOS/Cherish-iOS/Supports/AppDelegate.swift
+++ b/Cherish-iOS/Cherish-iOS/Supports/AppDelegate.swift
@@ -44,14 +44,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             application.registerForRemoteNotifications()
         } else {
             let settings: UIUserNotificationSettings =
-                UIUserNotificationSettings(types: [.alert, .badge, .sound], categories: nil)
+            UIUserNotificationSettings(types: [.alert, .badge, .sound], categories: nil)
             application.registerUserNotificationSettings(settings)
             application.registerForRemoteNotifications()
-            
         }
-        
-        // [END register_for_notifications
-        
+        // [END register_for_notifications]
         return true
     }
     

--- a/Cherish-iOS/Cherish-iOS/Supports/SceneDelegate.swift
+++ b/Cherish-iOS/Cherish-iOS/Supports/SceneDelegate.swift
@@ -30,12 +30,12 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                 print("첫 로드 : 로그인뷰")
                 let storyboard = UIStoryboard(name: "Login", bundle: nil)
                 let vc = storyboard.instantiateViewController(withIdentifier: "LoginVC")
-                initialViewController = UINavigationController(rootViewController: vc)
+                initialViewController = NavigationController(rootViewController: vc)
             } else {
                 print("첫 로드 : 온보딩뷰")
                 let storyBoard = UIStoryboard(name: "Onboarding", bundle: nil)
                 let vc = storyBoard.instantiateViewController(identifier: "OnboardingVC")
-                initialViewController = UINavigationController(rootViewController: vc)
+                initialViewController = NavigationController(rootViewController: vc)
             }
         }
         


### PR DESCRIPTION
### ✅ PR check list
```
- commit message가 적절한지 확인해주세요. 
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 가능한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제 부탁드립니다.
```

## 🌈 PR 요약
1) 식물 물주기 -> 카톡으로 물을 줬을 경우 -> 체리쉬 앱으로 돌아와서 -> 기록 남긴 후 -> 물주기 모션이 블라인드로 처리되어 보여짐
- [x] 1번 이슈 해결: 연락하기로 넘어갈때 가림막 add 된 뒤에 리뷰하기 뷰가 add돼서 블라인드가 안지워짐

2) 앱 첫 가입 이후 -> 첫 식물 등록 -> 메인 홈으로 진입시 -> 하단 탭바가 보이지 않음(단, 앱을 껏다 키면 탭바가 올바르게 생성됨)
- [x] 2번 이슈 해결: 뷰 맵핑 오류 탭바뷰로 매핑하여 해결

3) 홈 하단 탭바 영역에 양쪽 사이드에 여백이 생김 -> 아이폰 사용시 폰 화면이 둥그러서 사용상 문제를 못느끼지만 -> 캡처시 하단에 여백이 나타남
- [x] 3번 이슈 해결: 체리시 서랍이 라운드가 4코너 다 먹혀있어서 2코너만 먹여서 해결

4) 미루기 기능에서 현재 날짜 기준으로 미룰 날짜를 계산하여 보여주는데 이 부분의 계산이 잘못되고 있음
- [x] 4번 이슈 해결: 날짜 계산 로직 개선

#### Linked Issue
close #49 
