### PR TITLE
[Hotfix/#51] 식물 추가시 탭바 두개 쌓이는 버그 해결

### DIFF
--- a/Cherish-iOS/Cherish-iOS.xcodeproj/project.pbxproj
+++ b/Cherish-iOS/Cherish-iOS.xcodeproj/project.pbxproj
@@ -161,7 +161,6 @@
 		54AE98BE25F3C02900993EA3 /* WithdrawalService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54AE98BD25F3C02900993EA3 /* WithdrawalService.swift */; };
 		54D8D627271185C2002BD09C /* CherishTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54D8D626271185C2002BD09C /* CherishTextField.swift */; };
 		54D8D62A271186BB002BD09C /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 54D8D629271186BB002BD09C /* SnapKit */; };
-		54D8D62D271186E7002BD09C /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = 54D8D62C271186E7002BD09C /* Then */; };
 		54D8D62F27118C7B002BD09C /* UIFont+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54D8D62E27118C7B002BD09C /* UIFont+.swift */; };
 		54D8D63327118E75002BD09C /* LetterSpacing+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54D8D63227118E75002BD09C /* LetterSpacing+.swift */; };
 		54D8D635271190C4002BD09C /* SignUpAccountVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54D8D634271190C4002BD09C /* SignUpAccountVC.swift */; };
@@ -179,7 +178,6 @@
 		54F9579C274E30F300D08050 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 54F9579B274E30F300D08050 /* Kingfisher */; };
 		54F9579F274E311800D08050 /* OverlayContainer in Frameworks */ = {isa = PBXBuildFile; productRef = 54F9579E274E311800D08050 /* OverlayContainer */; };
 		54F957AD275225FD00D08050 /* NavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F957AC275225FD00D08050 /* NavigationController.swift */; };
-		6267145A78CCE15A17811AB0 /* Pods_Cherish_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3317F22D029D112E0B804F84 /* Pods_Cherish_iOS.framework */; };
 		9214410225ACE7BD00853E53 /* AddUserService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9214410125ACE7BD00853E53 /* AddUserService.swift */; };
 		923F8CDF25A1C2E400EA04E5 /* InputDetailVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 923F8CDE25A1C2E400EA04E5 /* InputDetailVC.swift */; };
 		9244DF0C25AB90F00014FF5D /* PlantResultVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9244DF0B25AB90F00014FF5D /* PlantResultVC.swift */; };
@@ -209,6 +207,8 @@
 		92DCC3E525A85D1D00160523 /* AddUser.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 92E8E39625A1B13F001F1FB4 /* AddUser.storyboard */; };
 		92DCC3EA25A85D7100160523 /* SelectFriendCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DCC3E825A85D7100160523 /* SelectFriendCell.swift */; };
 		92DCC3EB25A85D7100160523 /* SelectFriendCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 92DCC3E925A85D7100160523 /* SelectFriendCell.xib */; };
+		E80B48B527CD01D300704AA9 /* Pods_Cherish_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3317F22D029D112E0B804F84 /* Pods_Cherish_iOS.framework */; };
+		E8B5FAC927CD06BF00B5AFCE /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = E8B5FAC827CD06BF00B5AFCE /* Then */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -422,9 +422,9 @@
 			files = (
 				54F9579C274E30F300D08050 /* Kingfisher in Frameworks */,
 				54F9579F274E311800D08050 /* OverlayContainer in Frameworks */,
-				6267145A78CCE15A17811AB0 /* Pods_Cherish_iOS.framework in Frameworks */,
 				54F95796274E30C800D08050 /* Alamofire in Frameworks */,
-				54D8D62D271186E7002BD09C /* Then in Frameworks */,
+				E8B5FAC927CD06BF00B5AFCE /* Then in Frameworks */,
+				E80B48B527CD01D300704AA9 /* Pods_Cherish_iOS.framework in Frameworks */,
 				54F95799274E30D600D08050 /* FSCalendar in Frameworks */,
 				54D8D62A271186BB002BD09C /* SnapKit in Frameworks */,
 			);
@@ -1396,11 +1396,11 @@
 			name = "Cherish-iOS";
 			packageProductDependencies = (
 				54D8D629271186BB002BD09C /* SnapKit */,
-				54D8D62C271186E7002BD09C /* Then */,
 				54F95795274E30C800D08050 /* Alamofire */,
 				54F95798274E30D600D08050 /* FSCalendar */,
 				54F9579B274E30F300D08050 /* Kingfisher */,
 				54F9579E274E311800D08050 /* OverlayContainer */,
+				E8B5FAC827CD06BF00B5AFCE /* Then */,
 			);
 			productName = "Cherish-iOS";
 			productReference = 33851C70259A5541005BCFFD /* Cherish-iOS.app */;
@@ -1431,11 +1431,11 @@
 			mainGroup = 33851C67259A5541005BCFFD;
 			packageReferences = (
 				54D8D628271186BB002BD09C /* XCRemoteSwiftPackageReference "SnapKit" */,
-				54D8D62B271186E7002BD09C /* XCRemoteSwiftPackageReference "Then" */,
 				54F95794274E30C800D08050 /* XCRemoteSwiftPackageReference "Alamofire" */,
 				54F95797274E30D600D08050 /* XCRemoteSwiftPackageReference "FSCalendar" */,
 				54F9579A274E30F300D08050 /* XCRemoteSwiftPackageReference "Kingfisher" */,
 				54F9579D274E311800D08050 /* XCRemoteSwiftPackageReference "OverlayContainer" */,
+				E8B5FAC727CD06BF00B5AFCE /* XCRemoteSwiftPackageReference "Then" */,
 			);
 			productRefGroup = 33851C71259A5541005BCFFD /* Products */;
 			projectDirPath = "";
@@ -1752,6 +1752,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				EXCLUDED_ARCHS = "";
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -1813,6 +1814,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				EXCLUDED_ARCHS = "";
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -1824,6 +1826,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
@@ -1842,6 +1845,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = 2ZS26WP93H;
+				EXCLUDED_ARCHS = "";
 				INFOPLIST_FILE = "Cherish-iOS/Supports/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1868,6 +1872,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = 2ZS26WP93H;
+				EXCLUDED_ARCHS = "";
 				INFOPLIST_FILE = "Cherish-iOS/Supports/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1875,6 +1880,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.8;
+				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "iOS.Cherish.Cherish-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1915,14 +1921,6 @@
 				minimumVersion = 5.0.0;
 			};
 		};
-		54D8D62B271186E7002BD09C /* XCRemoteSwiftPackageReference "Then" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/devxoul/Then";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 2.0.0;
-			};
-		};
 		54F95794274E30C800D08050 /* XCRemoteSwiftPackageReference "Alamofire" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Alamofire/Alamofire.git";
@@ -1955,6 +1953,14 @@
 				minimumVersion = 3.0.0;
 			};
 		};
+		E8B5FAC727CD06BF00B5AFCE /* XCRemoteSwiftPackageReference "Then" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/devxoul/Then";
+			requirement = {
+				branch = master;
+				kind = branch;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1962,11 +1968,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 54D8D628271186BB002BD09C /* XCRemoteSwiftPackageReference "SnapKit" */;
 			productName = SnapKit;
-		};
-		54D8D62C271186E7002BD09C /* Then */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 54D8D62B271186E7002BD09C /* XCRemoteSwiftPackageReference "Then" */;
-			productName = Then;
 		};
 		54F95795274E30C800D08050 /* Alamofire */ = {
 			isa = XCSwiftPackageProductDependency;
@@ -1987,6 +1988,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 54F9579D274E311800D08050 /* XCRemoteSwiftPackageReference "OverlayContainer" */;
 			productName = OverlayContainer;
+		};
+		E8B5FAC827CD06BF00B5AFCE /* Then */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E8B5FAC727CD06BF00B5AFCE /* XCRemoteSwiftPackageReference "Then" */;
+			productName = Then;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Cherish-iOS/Cherish-iOS.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Cherish-iOS/Cherish-iOS.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -50,9 +50,9 @@
         "package": "Then",
         "repositoryURL": "https://github.com/devxoul/Then",
         "state": {
-          "branch": null,
+          "branch": "master",
           "revision": "e421a7b3440a271834337694e6050133a3958bc7",
-          "version": "2.7.0"
+          "version": null
         }
       }
     ]

--- a/Cherish-iOS/Cherish-iOS/Screens/AddUser/Controllers/InputDetailVC.swift
+++ b/Cherish-iOS/Cherish-iOS/Screens/AddUser/Controllers/InputDetailVC.swift
@@ -131,7 +131,6 @@ class InputDetailVC: BaseController {
                                 self.navigationController?.pushViewController(resultVC, animated: true)
                             }
                         }
-                        self.navigationController?.pushViewController(resultVC, animated: true)
                     }
                 case .requestErr(_):
                     print("requesetErr")

--- a/Cherish-iOS/Cherish-iOS/Screens/AddUser/Controllers/PlantResultVC.swift
+++ b/Cherish-iOS/Cherish-iOS/Screens/AddUser/Controllers/PlantResultVC.swift
@@ -88,7 +88,7 @@ class PlantResultVC: BaseController {
             UserDefaults.standard.set("", forKey: "selectedModifierData")
             UserDefaults.standard.set(true, forKey: "addUser")
             self.navigationController?.interactivePopGestureRecognizer?.isEnabled = true
-            self.navigationController?.setViewControllers([vc], animated: true)
+			self.dismiss(animated: true, completion: nil)
         }
     }
     

--- a/Cherish-iOS/Cherish-iOS/Screens/AddUser/Controllers/SelectFriendSearchBar.swift
+++ b/Cherish-iOS/Cherish-iOS/Screens/AddUser/Controllers/SelectFriendSearchBar.swift
@@ -14,7 +14,8 @@ class SelectFriendSearchBar: BaseController, UITableViewDataSource, UITableViewD
     
     @IBOutlet weak var tableView: UITableView!
     @IBOutlet weak var nextBtn: UIButton!
-    @IBOutlet weak var searchBar: UISearchBar!
+	@IBOutlet weak var backBtn: UIButton!
+	@IBOutlet weak var searchBar: UISearchBar!
     @IBOutlet var noContactsView: UIView!
     
     var friendList: [Friend] = []
@@ -57,8 +58,7 @@ class SelectFriendSearchBar: BaseController, UITableViewDataSource, UITableViewD
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        /// 이렇게 하면 버튼 타이틀이 가운데로 안온다
-//        nextBtn.isEnabled = false
+		setNaviBarIcon()
         tableView.separatorStyle = .none
         tableView.dataSource = self
         tableView.delegate = self
@@ -207,7 +207,12 @@ class SelectFriendSearchBar: BaseController, UITableViewDataSource, UITableViewD
     }
     
     @IBAction func closeToMain(_ sender: Any) {
-        self.navigationController?.popViewController(animated: true)
+		guard let navigationController = self.navigationController else { return }
+		if navigationController.viewControllers.count >= 2 {
+			navigationController.popViewController(animated: true)
+		} else {
+			self.dismiss(animated: true)
+		}
     }
     
     @IBAction func touchUpNextBtn(_ sender: Any) {
@@ -284,6 +289,15 @@ class SelectFriendSearchBar: BaseController, UITableViewDataSource, UITableViewD
         searchBar.searchTextField.textColor = UIColor.cherishBlack
         searchBar.searchTextField.font = UIFont.init(name: "NotoSansCJKKR-Regular", size: 14)
     }
+	
+	func setNaviBarIcon() {
+		guard let navigationController = self.navigationController else { return }
+		if navigationController.viewControllers.count >= 2 {
+			backBtn.setImageByName(name: "icn_back", selectedName: "icn_back")
+		} else {
+			backBtn.setImageByName(name: "icnCancel", selectedName: "icnCancel")
+		}
+	}
     
     private func updateSelectedIndex(_ index: Int) {
         selectedFriend = index

--- a/Cherish-iOS/Cherish-iOS/Screens/AddUser/Controllers/SelectFriendSearchBar.swift
+++ b/Cherish-iOS/Cherish-iOS/Screens/AddUser/Controllers/SelectFriendSearchBar.swift
@@ -243,7 +243,6 @@ class SelectFriendSearchBar: BaseController, UITableViewDataSource, UITableViewD
                 switch networkResult {
                 case .success(_):
                     print("통신성공")
-                    dvc.modalPresentationStyle = .fullScreen
                     self.navigationController?.pushViewController(dvc, animated: true)
                     
                 case .requestErr(_):

--- a/Cherish-iOS/Cherish-iOS/Screens/AddUser/Storyboards/AddUser.storyboard
+++ b/Cherish-iOS/Cherish-iOS/Screens/AddUser/Storyboards/AddUser.storyboard
@@ -615,7 +615,7 @@
         <!--SelectFriendSearchBar-->
         <scene sceneID="hPq-AR-aYG">
             <objects>
-                <viewController storyboardIdentifier="SelectFriendSearchBar" title="SelectFriendSearchBar" modalPresentationStyle="fullScreen" hidesBottomBarWhenPushed="YES" id="4c4-J9-nWF" customClass="SelectFriendSearchBar" customModule="Cherish_iOS" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="SelectFriendSearchBar" title="SelectFriendSearchBar" hidesBottomBarWhenPushed="YES" id="4c4-J9-nWF" customClass="SelectFriendSearchBar" customModule="Cherish_iOS" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="qCe-J9-pfm">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -640,7 +640,7 @@
                                             <constraint firstAttribute="height" constant="44" id="8XM-TH-hgT"/>
                                             <constraint firstAttribute="width" secondItem="5ph-qV-iEy" secondAttribute="height" multiplier="1:1" id="cEy-y9-3qn"/>
                                         </constraints>
-                                        <state key="normal" image="icnBack"/>
+                                        <state key="normal" image="icn_back"/>
                                         <connections>
                                             <action selector="closeToMain:" destination="4c4-J9-nWF" eventType="touchUpInside" id="mR4-RS-LDY"/>
                                         </connections>
@@ -804,6 +804,7 @@
                     </view>
                     <navigationItem key="navigationItem" id="aZ3-nD-L9A"/>
                     <connections>
+                        <outlet property="backBtn" destination="5ph-qV-iEy" id="bzf-e2-4Xb"/>
                         <outlet property="nextBtn" destination="lRC-ne-zl0" id="pmJ-If-26C"/>
                         <outlet property="noContactsView" destination="aNY-rL-OKL" id="aPy-Fq-FAK"/>
                         <outlet property="searchBar" destination="IUJ-Hk-aUc" id="vZJ-7m-6vS"/>
@@ -819,7 +820,6 @@
         <image name="btn_checkbox_unselected" width="18" height="18"/>
         <image name="btn_next_selected" width="343" height="48"/>
         <image name="btn_next_unselected" width="343" height="48"/>
-        <image name="icnBack" width="44" height="44"/>
         <image name="icn_back" width="44" height="44"/>
         <image name="img_noplant_view" width="154" height="200"/>
         <namedColor name="black">

--- a/Cherish-iOS/Cherish-iOS/Screens/CherishMain/Controllers/DetailContentVC.swift
+++ b/Cherish-iOS/Cherish-iOS/Screens/CherishMain/Controllers/DetailContentVC.swift
@@ -82,8 +82,9 @@ class DetailContentVC: BaseController {
                         UserDefaults.standard.set(false, forKey: "isPlantExist")
                         let storyBoard: UIStoryboard = UIStoryboard(name: "AddUser", bundle: nil)
                         if let vc = storyBoard.instantiateViewController(identifier: "AddUserVC") as? AddUserVC {
-//                            vc.hidesBottomBarWhenPushed = true
-                            self?.navigationController?.setViewControllers([vc], animated: true)
+							let addVCWithNavigation = NavigationController(rootViewController: vc)
+							addVCWithNavigation.modalPresentationStyle = .fullScreen
+							self?.present(addVCWithNavigation, animated: true, completion: nil)
                         }
                     } else {
                         UserDefaults.standard.set(true, forKey: "isPlantExist")
@@ -268,7 +269,9 @@ class DetailContentVC: BaseController {
         let storyBoard: UIStoryboard = UIStoryboard(name: "AddUser", bundle: nil)
         if let vc = storyBoard.instantiateViewController(identifier: "SelectFriendSearchBar") as? SelectFriendSearchBar {
 //            vc.hidesBottomBarWhenPushed = true
-            self.navigationController?.pushViewController(vc, animated: true)
+			let addVCWithNavigation = NavigationController(rootViewController: vc)
+			addVCWithNavigation.modalPresentationStyle = .fullScreen
+			self.present(addVCWithNavigation, animated: true, completion: nil)
         }
     }
 }

--- a/Cherish-iOS/Cherish-iOS/Screens/MyPage/Controllers/MyPageSearchContactVC.swift
+++ b/Cherish-iOS/Cherish-iOS/Screens/MyPage/Controllers/MyPageSearchContactVC.swift
@@ -194,7 +194,6 @@ class MyPageSearchContactVC: BaseController, UITableViewDelegate, UITableViewDat
                 switch networkResult {
                 case .success(_):
                     print("통신성공")
-                    dvc.modalPresentationStyle = .fullScreen
                     self.navigationController?.pushViewController(dvc, animated: true)
                 case .requestErr(_):
                     print("requestErr")

--- a/Cherish-iOS/Cherish-iOS/Screens/MyPage/Controllers/MyPageVC.swift
+++ b/Cherish-iOS/Cherish-iOS/Screens/MyPage/Controllers/MyPageVC.swift
@@ -141,7 +141,8 @@ class MyPageVC: BaseController {
             (networkResult) -> (Void) in
             switch networkResult {
             case .success(let data):
-                if let mypageData = data as? MypageData {
+                if let mypageData = data as? MypageData,
+				   mypageData.result.count > 0 {
                     userNicknameLabel.text = "\(mypageData.userNickname)의 체리쉬가든"
                     userWateringCountLabel.text = "\(mypageData.waterCount)"
                     userWateringPostponeCountLabel.text = "\(mypageData.postponeCount)"
@@ -155,9 +156,6 @@ class MyPageVC: BaseController {
                     }
                     
                     UserDefaults.standard.set(myPlantID, forKey: "myCherishID")
-
-                    print("1: my page main임 ㅎㅇㅎㅇ")
-                    print(myPlantID)
                     UserDefaults.standard.set(myPlantID, forKey: "plantIDArray")
                     UserDefaults.standard.set(mypageData.email, forKey: "userEmail")
                     UserDefaults.standard.set(mypageData.userNickname, forKey: "userNickname")
@@ -235,7 +233,6 @@ class MyPageVC: BaseController {
     @IBAction func moveToSearchPlant(_ sender: Any) {
         print("이동한당")
         guard let dvc = self.storyboard?.instantiateViewController(identifier: "MyPageSearchVC") as? MyPageSearchVC else {return}
-        dvc.modalPresentationStyle = .fullScreen
         self.navigationController?.pushViewController(dvc, animated: true)
     }
     

--- a/Cherish-iOS/Cherish-iOS/Screens/MyPage/Controllers/MyPageVC.swift
+++ b/Cherish-iOS/Cherish-iOS/Screens/MyPage/Controllers/MyPageVC.swift
@@ -170,7 +170,15 @@ class MyPageVC: BaseController {
                     }
                     mypageContactCount = contactArray.count
                     segmentView.setButtonTitles(buttonTitles: ["식물 \(mypagePlantCount)", "연락처 \(mypageContactCount)"])
-                }
+				} else {
+					UserDefaults.standard.set(false, forKey: "isPlantExist")
+					let storyBoard: UIStoryboard = UIStoryboard(name: "AddUser", bundle: nil)
+					if let vc = storyBoard.instantiateViewController(identifier: "AddUserVC") as? AddUserVC {
+						let addVCWithNavigation = NavigationController(rootViewController: vc)
+						addVCWithNavigation.modalPresentationStyle = .fullScreen
+						self.present(addVCWithNavigation, animated: true, completion: nil)
+					}
+				}
             case .requestErr(let msg):
                 print(msg)
             case .pathErr:

--- a/Cherish-iOS/Podfile
+++ b/Cherish-iOS/Podfile
@@ -8,12 +8,4 @@ target 'Cherish-iOS' do
   # Pods for Cherish-iOS
   pod 'Firebase/Analytics'
   pod 'Firebase/Messaging'
-
-  post_install do |installer|
-    installer.pods_project.targets.each do |target|
-      target.build_configurations.each do |config|
-        config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '10.0'
-      end
-    end
-  end
 end

--- a/Cherish-iOS/Podfile.lock
+++ b/Cherish-iOS/Podfile.lock
@@ -1,82 +1,104 @@
 PODS:
-  - Firebase/Analytics (7.4.0):
+  - Firebase/Analytics (8.12.1):
     - Firebase/Core
-  - Firebase/Core (7.4.0):
+  - Firebase/Core (8.12.1):
     - Firebase/CoreOnly
-    - FirebaseAnalytics (= 7.4.0)
-  - Firebase/CoreOnly (7.4.0):
-    - FirebaseCore (= 7.4.0)
-  - Firebase/Messaging (7.4.0):
+    - FirebaseAnalytics (~> 8.12.0)
+  - Firebase/CoreOnly (8.12.1):
+    - FirebaseCore (= 8.12.1)
+  - Firebase/Messaging (8.12.1):
     - Firebase/CoreOnly
-    - FirebaseMessaging (~> 7.4.0)
-  - FirebaseAnalytics (7.4.0):
-    - FirebaseCore (~> 7.0)
-    - FirebaseInstallations (~> 7.0)
-    - GoogleAppMeasurement (= 7.4.0)
-    - GoogleUtilities/AppDelegateSwizzler (~> 7.0)
-    - GoogleUtilities/MethodSwizzler (~> 7.0)
-    - GoogleUtilities/Network (~> 7.0)
-    - "GoogleUtilities/NSData+zlib (~> 7.0)"
-    - nanopb (~> 2.30907.0)
-  - FirebaseCore (7.4.0):
-    - FirebaseCoreDiagnostics (~> 7.4)
-    - GoogleUtilities/Environment (~> 7.0)
-    - GoogleUtilities/Logger (~> 7.0)
-  - FirebaseCoreDiagnostics (7.4.0):
-    - GoogleDataTransport (~> 8.0)
-    - GoogleUtilities/Environment (~> 7.0)
-    - GoogleUtilities/Logger (~> 7.0)
-    - nanopb (~> 2.30907.0)
-  - FirebaseInstallations (7.4.0):
-    - FirebaseCore (~> 7.0)
-    - GoogleUtilities/Environment (~> 7.0)
-    - GoogleUtilities/UserDefaults (~> 7.0)
-    - PromisesObjC (~> 1.2)
-  - FirebaseInstanceID (7.4.0):
-    - FirebaseCore (~> 7.0)
-    - FirebaseInstallations (~> 7.0)
-    - GoogleUtilities/Environment (~> 7.0)
-    - GoogleUtilities/UserDefaults (~> 7.0)
-  - FirebaseMessaging (7.4.0):
-    - FirebaseCore (~> 7.0)
-    - FirebaseInstanceID (~> 7.0)
-    - GoogleUtilities/AppDelegateSwizzler (~> 7.0)
-    - GoogleUtilities/Environment (~> 7.0)
-    - GoogleUtilities/Reachability (~> 7.0)
-    - GoogleUtilities/UserDefaults (~> 7.0)
-  - GoogleAppMeasurement (7.4.0):
-    - GoogleUtilities/AppDelegateSwizzler (~> 7.0)
-    - GoogleUtilities/MethodSwizzler (~> 7.0)
-    - GoogleUtilities/Network (~> 7.0)
-    - "GoogleUtilities/NSData+zlib (~> 7.0)"
-    - nanopb (~> 2.30907.0)
-  - GoogleDataTransport (8.2.0):
-    - nanopb (~> 2.30907.0)
-  - GoogleUtilities/AppDelegateSwizzler (7.2.0):
+    - FirebaseMessaging (~> 8.12.0)
+  - FirebaseAnalytics (8.12.0):
+    - FirebaseAnalytics/AdIdSupport (= 8.12.0)
+    - FirebaseCore (~> 8.0)
+    - FirebaseInstallations (~> 8.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
+    - GoogleUtilities/MethodSwizzler (~> 7.7)
+    - GoogleUtilities/Network (~> 7.7)
+    - "GoogleUtilities/NSData+zlib (~> 7.7)"
+    - nanopb (~> 2.30908.0)
+  - FirebaseAnalytics/AdIdSupport (8.12.0):
+    - FirebaseCore (~> 8.0)
+    - FirebaseInstallations (~> 8.0)
+    - GoogleAppMeasurement (= 8.12.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
+    - GoogleUtilities/MethodSwizzler (~> 7.7)
+    - GoogleUtilities/Network (~> 7.7)
+    - "GoogleUtilities/NSData+zlib (~> 7.7)"
+    - nanopb (~> 2.30908.0)
+  - FirebaseCore (8.12.1):
+    - FirebaseCoreDiagnostics (~> 8.0)
+    - GoogleUtilities/Environment (~> 7.7)
+    - GoogleUtilities/Logger (~> 7.7)
+  - FirebaseCoreDiagnostics (8.12.0):
+    - GoogleDataTransport (~> 9.1)
+    - GoogleUtilities/Environment (~> 7.7)
+    - GoogleUtilities/Logger (~> 7.7)
+    - nanopb (~> 2.30908.0)
+  - FirebaseInstallations (8.12.0):
+    - FirebaseCore (~> 8.0)
+    - GoogleUtilities/Environment (~> 7.7)
+    - GoogleUtilities/UserDefaults (~> 7.7)
+    - PromisesObjC (< 3.0, >= 1.2)
+  - FirebaseMessaging (8.12.0):
+    - FirebaseCore (~> 8.0)
+    - FirebaseInstallations (~> 8.0)
+    - GoogleDataTransport (~> 9.1)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
+    - GoogleUtilities/Environment (~> 7.7)
+    - GoogleUtilities/Reachability (~> 7.7)
+    - GoogleUtilities/UserDefaults (~> 7.7)
+    - nanopb (~> 2.30908.0)
+  - GoogleAppMeasurement (8.12.0):
+    - GoogleAppMeasurement/AdIdSupport (= 8.12.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
+    - GoogleUtilities/MethodSwizzler (~> 7.7)
+    - GoogleUtilities/Network (~> 7.7)
+    - "GoogleUtilities/NSData+zlib (~> 7.7)"
+    - nanopb (~> 2.30908.0)
+  - GoogleAppMeasurement/AdIdSupport (8.12.0):
+    - GoogleAppMeasurement/WithoutAdIdSupport (= 8.12.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
+    - GoogleUtilities/MethodSwizzler (~> 7.7)
+    - GoogleUtilities/Network (~> 7.7)
+    - "GoogleUtilities/NSData+zlib (~> 7.7)"
+    - nanopb (~> 2.30908.0)
+  - GoogleAppMeasurement/WithoutAdIdSupport (8.12.0):
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
+    - GoogleUtilities/MethodSwizzler (~> 7.7)
+    - GoogleUtilities/Network (~> 7.7)
+    - "GoogleUtilities/NSData+zlib (~> 7.7)"
+    - nanopb (~> 2.30908.0)
+  - GoogleDataTransport (9.1.2):
+    - GoogleUtilities/Environment (~> 7.2)
+    - nanopb (~> 2.30908.0)
+    - PromisesObjC (< 3.0, >= 1.2)
+  - GoogleUtilities/AppDelegateSwizzler (7.7.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
-  - GoogleUtilities/Environment (7.2.0):
-    - PromisesObjC (~> 1.2)
-  - GoogleUtilities/Logger (7.2.0):
+  - GoogleUtilities/Environment (7.7.0):
+    - PromisesObjC (< 3.0, >= 1.2)
+  - GoogleUtilities/Logger (7.7.0):
     - GoogleUtilities/Environment
-  - GoogleUtilities/MethodSwizzler (7.2.0):
+  - GoogleUtilities/MethodSwizzler (7.7.0):
     - GoogleUtilities/Logger
-  - GoogleUtilities/Network (7.2.0):
+  - GoogleUtilities/Network (7.7.0):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (7.2.0)"
-  - GoogleUtilities/Reachability (7.2.0):
+  - "GoogleUtilities/NSData+zlib (7.7.0)"
+  - GoogleUtilities/Reachability (7.7.0):
     - GoogleUtilities/Logger
-  - GoogleUtilities/UserDefaults (7.2.0):
+  - GoogleUtilities/UserDefaults (7.7.0):
     - GoogleUtilities/Logger
-  - nanopb (2.30907.0):
-    - nanopb/decode (= 2.30907.0)
-    - nanopb/encode (= 2.30907.0)
-  - nanopb/decode (2.30907.0)
-  - nanopb/encode (2.30907.0)
-  - PromisesObjC (1.2.12)
+  - nanopb (2.30908.0):
+    - nanopb/decode (= 2.30908.0)
+    - nanopb/encode (= 2.30908.0)
+  - nanopb/decode (2.30908.0)
+  - nanopb/encode (2.30908.0)
+  - PromisesObjC (2.0.0)
 
 DEPENDENCIES:
   - Firebase/Analytics
@@ -89,7 +111,6 @@ SPEC REPOS:
     - FirebaseCore
     - FirebaseCoreDiagnostics
     - FirebaseInstallations
-    - FirebaseInstanceID
     - FirebaseMessaging
     - GoogleAppMeasurement
     - GoogleDataTransport
@@ -98,19 +119,18 @@ SPEC REPOS:
     - PromisesObjC
 
 SPEC CHECKSUMS:
-  Firebase: 09fb40287b6dfc8ee65f726fa0b788719d3f2a07
-  FirebaseAnalytics: adb3c8f02f83d00661cdaac6dbb4d54e9720d1b6
-  FirebaseCore: 99c06e5a1e8d6952e75cb1f0a6d0b23c0f5ccdcf
-  FirebaseCoreDiagnostics: 3770093ac4f2be4590fa03cfa1d3a6e5602d4557
-  FirebaseInstallations: 30646fc9a61c6f4ee3cd7a8b7231721842b40c95
-  FirebaseInstanceID: 46d93d287108246fabbd85371ca27141d2c21ff9
-  FirebaseMessaging: 6112b5cd04e0ff58c4a9920e5e29cf193ea88439
-  GoogleAppMeasurement: 688d7f00e2894d9e13823ed9a028b13b993bc277
-  GoogleDataTransport: 1024b1a4dfbd7a0e92cb20d7e0a6f1fb66b449a4
-  GoogleUtilities: d866834472f1324d080496bc67ab3ce5d0d46027
-  nanopb: 59221d7f958fb711001e6a449489542d92ae113e
-  PromisesObjC: 3113f7f76903778cf4a0586bd1ab89329a0b7b97
+  Firebase: 580d09e8edafc3073ebf09c03fd42e4d80d35fe9
+  FirebaseAnalytics: bd10d7706ba8d6e01ea2816f8fe9e9b881cb0918
+  FirebaseCore: 8138de860a90ca7eec5e324da5788fb0ebf1d93c
+  FirebaseCoreDiagnostics: 3b40dfadef5b90433a60ae01f01e90fe87aa76aa
+  FirebaseInstallations: 25764cf322e77f99449395870a65b2bef88e1545
+  FirebaseMessaging: 23db8bf05585e929ada8af0f0968933c25252808
+  GoogleAppMeasurement: ae033c3aad67e68294369373056b4d74cc8ae0d6
+  GoogleDataTransport: 629c20a4d363167143f30ea78320d5a7eb8bd940
+  GoogleUtilities: e0913149f6b0625b553d70dae12b49fc62914fd1
+  nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
+  PromisesObjC: 68159ce6952d93e17b2dfe273b8c40907db5ba58
 
-PODFILE CHECKSUM: ddee8283dd742254211af8f4535591496dd45f08
+PODFILE CHECKSUM: 9b3f8500adb5f51937a1e0e19a5cb7f93558f538
 
-COCOAPODS: 1.10.0
+COCOAPODS: 1.11.2


### PR DESCRIPTION
### ✅ PR check list
```
- commit message가 적절한지 확인해주세요. 
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 가능한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제 부탁드립니다.
```

## 🌈 PR 요약
식물 추가시 탭바 두개 쌓이는 버그 해결

현재 우리 식물추가 flow가 NavigationStack으로 쌓이는 방식인데 같은 NavigationController를 공유하고 있어서 생긴 버그에요
식물이 등록 완료된 이후 새롭게 스택을 초기화해주었지만, 네비(탭바(네비,네비,네비)) 이런식으로 되어서 탭바가 하나 더 생겼었습니다. 탭바는 애초에 네비로 감싸져있지 않았거든요 탭바 안에 있는 뷰가 네비로 감싸져있고!

무튼 해결했는데 하다보니 식물 추가 flow가 push로 뷰 전환이 이루어지는게 어색해보이더라구요. 홈에서 추가가 이루어질때도 push로 flow가 진행되고 마쳤을 때 pop을 하는것도 이상했고 push를 하자니 회전목마처럼 홈 -> 1 -> 2 -> 3 -> 4 -> 홈 이렇게 돼서 계속 뷰가 쌓이는 느낌이 들고..

그래서 flow 전체는 present, dismiss 방식으로 가되, 그 안에서는 push 트랜지션을 사용하도록 바꿔놓았습니다.

## 📌 변경 사항
마이페이지에서 식물이 0개가 되었을 때 식물추가뷰를 띄우는 로직이 없어서 앱이 크래시가나길래 그 로직 추가했어요

## 📸 ScreenShot

![Simulator Screen Recording - iPhone 12 mini - 2022-03-01 at 00 26 37](https://user-images.githubusercontent.com/42789819/156009972-4c557703-3935-41a1-89cd-689d2b954305.gif) ![Simulator Screen Recording - iPhone 12 mini - 2022-03-01 at 00 25 55](https://user-images.githubusercontent.com/42789819/156009852-18a5452b-2c12-4b8d-aa17-01533cb6d89b.gif)


#### Linked Issue
close #51 

