### PR TITLE
[Hotfix/#57] 식물등록 결과창에서 다음 화면으로 안넘어가는 버그 수정

### DIFF
--- a/Cherish-iOS/Cherish-iOS/Screens/AddUser/Controllers/PlantResultVC.swift
+++ b/Cherish-iOS/Cherish-iOS/Screens/AddUser/Controllers/PlantResultVC.swift
@@ -78,17 +78,23 @@ class PlantResultVC: BaseController {
     
     @IBAction func startToMain(_ sender: UIButton) {
         NotificationCenter.default.post(name: .addUser, object: nil)
-        let storyboard = UIStoryboard(name: "TabBar", bundle: nil)
-        if let vc = storyboard.instantiateViewController(withIdentifier: "CherishTabBarController") as? CherishTabBarController {
-            isCherishDataChanged.shared.status = true
-            UserDefaults.standard.set(true, forKey: "isPlantExist")
-            UserDefaults.standard.set("", forKey: "selectedNickNameData")
-            UserDefaults.standard.set(0, forKey: "selectedGrowthData")
-            UserDefaults.standard.set(0, forKey: "selectedGrowthData")
-            UserDefaults.standard.set("", forKey: "selectedModifierData")
-            UserDefaults.standard.set(true, forKey: "addUser")
-            self.navigationController?.interactivePopGestureRecognizer?.isEnabled = true
-			self.dismiss(animated: true, completion: nil)
+        isCherishDataChanged.shared.status = true
+        UserDefaults.standard.set(true, forKey: "isPlantExist")
+        UserDefaults.standard.set("", forKey: "selectedNickNameData")
+        UserDefaults.standard.set(0, forKey: "selectedGrowthData")
+        UserDefaults.standard.set(0, forKey: "selectedGrowthData")
+        UserDefaults.standard.set("", forKey: "selectedModifierData")
+        UserDefaults.standard.set(true, forKey: "addUser")
+        self.navigationController?.interactivePopGestureRecognizer?.isEnabled = true
+        guard self.presentingViewController == nil else {
+            self.dismiss(animated: true, completion: nil)
+            return
+        }
+        
+        let tabBarStoyboard: UIStoryboard = UIStoryboard(name: "TabBar", bundle: nil)
+        if let tabBarVC = tabBarStoyboard.instantiateViewController(identifier: "CherishTabBarController") as? CherishTabBarController {
+            
+            self.navigationController?.pushViewController(tabBarVC, animated: true)
         }
     }
     

--- a/Cherish-iOS/Cherish-iOS/Screens/CherishMain/Controllers/DetailContentVC.swift
+++ b/Cherish-iOS/Cherish-iOS/Screens/CherishMain/Controllers/DetailContentVC.swift
@@ -266,8 +266,8 @@ class DetailContentVC: BaseController {
     private func setCherishPeopleCVSelectedItem() {
         if cherishPeopleData.count > 1 {
             cherishPeopleCV.selectItem(at: IndexPath(item: 1, section: 0), animated: true, scrollPosition: .top)
-            collectionView(self.cherishPeopleCV, didSelectItemAt: IndexPath(item: 1, section: 0))
         }
+        collectionView(self.cherishPeopleCV, didSelectItemAt: IndexPath(item: 1, section: 0))
     }
     
     //MARK: - 친구추가 뷰로 이동

--- a/Cherish-iOS/Cherish-iOS/Screens/CherishMain/Controllers/DetailContentVC.swift
+++ b/Cherish-iOS/Cherish-iOS/Screens/CherishMain/Controllers/DetailContentVC.swift
@@ -49,7 +49,6 @@ class DetailContentVC: BaseController {
     
     override func viewWillAppear(_ animated: Bool) {
         if isCherishDataChanged.shared.status {
-            setCherishPeopleCVSelectedItem()
             setCherishPeopleData()
             isCherishDataChanged.shared.status = false
         }

--- a/Cherish-iOS/Cherish-iOS/Screens/CherishMain/Controllers/DetailContentVC.swift
+++ b/Cherish-iOS/Cherish-iOS/Screens/CherishMain/Controllers/DetailContentVC.swift
@@ -50,6 +50,7 @@ class DetailContentVC: BaseController {
     override func viewWillAppear(_ animated: Bool) {
         if isCherishDataChanged.shared.status {
             setCherishPeopleData()
+            setCherishPeopleCVSelectedItem()
             isCherishDataChanged.shared.status = false
         }
     }
@@ -263,8 +264,10 @@ class DetailContentVC: BaseController {
     }
     
     private func setCherishPeopleCVSelectedItem() {
-        cherishPeopleCV.selectItem(at: IndexPath(item: 1, section: 0), animated: true, scrollPosition: .top)
-        collectionView(self.cherishPeopleCV, didSelectItemAt: IndexPath(item: 1, section: 0))
+        if cherishPeopleData.count > 1 {
+            cherishPeopleCV.selectItem(at: IndexPath(item: 1, section: 0), animated: true, scrollPosition: .top)
+            collectionView(self.cherishPeopleCV, didSelectItemAt: IndexPath(item: 1, section: 0))
+        }
     }
     
     //MARK: - 친구추가 뷰로 이동

--- a/Cherish-iOS/Cherish-iOS/Screens/MyPage/Controllers/MyPageSearchPlantVC.swift
+++ b/Cherish-iOS/Cherish-iOS/Screens/MyPage/Controllers/MyPageSearchPlantVC.swift
@@ -118,10 +118,11 @@ class MyPageSearchPlantVC: BaseController {
         let storyBoard: UIStoryboard = UIStoryboard(name: "AddUser", bundle: nil)
         
         guard let dvc = storyBoard.instantiateViewController(identifier: "SelectFriendSearchBar") as? SelectFriendSearchBar else {return}
-//        dvc.hidesBottomBarWhenPushed = true
-        self.navigationController?.pushViewController(dvc, animated: true)
+        let selectFreindVCWithNavigation = NavigationController(rootViewController: dvc)
+        selectFreindVCWithNavigation.modalPresentationStyle = .fullScreen
+        self.present(selectFreindVCWithNavigation, animated: true, completion: nil)
     }
-    }
+}
 
 extension MyPageSearchPlantVC: UITableViewDelegate, UITableViewDataSource {
  

--- a/Cherish-iOS/Cherish-iOS/Screens/MyPage/Controllers/MyPageVC.swift
+++ b/Cherish-iOS/Cherish-iOS/Screens/MyPage/Controllers/MyPageVC.swift
@@ -251,7 +251,9 @@ class MyPageVC: BaseController {
         
         guard let dvc = storyBoard.instantiateViewController(identifier: "SelectFriendSearchBar") as? SelectFriendSearchBar else {return}
 //        dvc.hidesBottomBarWhenPushed = true
-        self.navigationController?.pushViewController(dvc, animated: true)
+        let selectFreindVCWithNavigation = NavigationController(rootViewController: dvc)
+        selectFreindVCWithNavigation.modalPresentationStyle = .fullScreen
+        self.present(selectFreindVCWithNavigation, animated: true, completion: nil)
     }
 }
 


### PR DESCRIPTION
### ✅ PR check list
```
- commit message가 적절한지 확인해주세요. 
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 가능한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제 부탁드립니다.
```

## 🌈 PR 요약
저번 PR에서 식물등록 flow를 present, dismiss형식으로 바꾸면서 미처 못바꿨던 부분들이 존재했나봐여 그 부분 수정했어요

근데 회원가입 후 최초 등록시에는 좀 달랐던게
식물 등록이 완료되면 PlantResult에서 
```swift
isCherishDataChanged.shared.status = true
```
요 코드로 인해 메인화면(DetailContentVC)은 아직 식물 데이터를 받아오기 전인데 컬렉션뷰의 첫번째 인덱스를 선택시켜주는 `setCherishPeopleCVSelectedItem` 메서드가 viewWillAppear()에서 호출되고 있는 이슈가 있어서 앱이 크래쉬가 나고 있었어용 

어차피 `cherishPeopleData`의 프로퍼티 옵저버 부분에 그 메서드가 구현이 되어있길래 viewWillAppear()에서는 제거해뒀는데 @Juhee-Hwang 확인 한번만 부탁드립미당

#### Linked Issue
close #57 
